### PR TITLE
Separate game lobbies 

### DIFF
--- a/client/src/components/GameSelector.jsx
+++ b/client/src/components/GameSelector.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import GameButton from "./gameButton";
 import "./GameSelector.css";
+import { socket } from "../socket.js";
 
 //create list of games to choose from with corresponding ID
 const games = [
@@ -17,10 +18,12 @@ function GameSelector() {
     return Math.random().toString(36).substring(2, 6).toUpperCase();
   };
 
-  const handleHostGame = () => {
-    if (!selectedGame) return;
-
+  const handleHostGame = (game_id) => {
     const roomID = generateRoomID();
+    if (game_id == 1) {
+      socket.emit("setGame", "pong");
+      socket.emit("joinRoom", roomID);
+    }
     navigate(`/lobby/${roomID}`, { state: { gameName: selectedGame } });
   };
 
@@ -33,17 +36,17 @@ function GameSelector() {
             key={game.id}
             game={game}
             isSelected={selectedGame === game.id}
-            onSelect={setSelectedGame}
+            onSelect={handleHostGame}
           />
         ))}
       </div>
-      <button
+      {/* <button
         className="host-button"
-        onClick={handleHostGame}
+        //onClick={handleHostGame}
         disabled={!selectedGame}
       >
         Host
-      </button>
+      </button> */}
     </>
   );
 }

--- a/client/src/componets/PongGame.css
+++ b/client/src/componets/PongGame.css
@@ -3,13 +3,20 @@
   box-sizing: border-box;
   background-color: white;
   color: black;
-  height: 50vw;
-  width: 70vw;
+  margin-left: auto;
+  margin-right: auto;
+  height: 46vw; /* using vw for height over vh to not have dynamic aspect ratio */
+  width: 65vw;
 }
 
 .player {
   height: 15%;
   width: 3%;
+}
+
+.scoreboard {
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .red-player {
@@ -31,4 +38,9 @@
   width: 3%;
   top: 50%;
   left: 50%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
 }

--- a/client/src/componets/PongGame.jsx
+++ b/client/src/componets/PongGame.jsx
@@ -11,6 +11,14 @@ function PongGame() {
 
   const moveUp = (prevPos) => Math.max(prevPos - 5, 0);
   const moveDown = (prevPos) => Math.min(prevPos + 5, 100);
+  const isCollision = function (paddlePos, ballPos) {
+    const hitboxWidth = 19;
+    const fraction = paddlePos / 100;
+    const lowerBound = paddlePos - hitboxWidth * fraction;
+    const upperBound = lowerBound + hitboxWidth;
+
+    return ballPos >= lowerBound && ballPos <= upperBound;
+  };
 
   useEffect(() => {
     let setPos;
@@ -45,14 +53,16 @@ function PongGame() {
         //update velocity based on hitting a wall or a player
         if (
           prevBallPos[0] + prevBallPos[2] <= 4 &&
-          redPos - prevBallPos[1] >= -5 &&
-          redPos - prevBallPos[1] <= 12
+          isCollision(redPos, prevBallPos[1])
+          // redPos - prevBallPos[1] >= -5 &&
+          // redPos - prevBallPos[1] <= 12
         )
           newState[2] = Math.abs(prevBallPos[2]);
         else if (
           prevBallPos[0] + prevBallPos[2] >= 96 &&
-          bluePos - prevBallPos[1] >= -5 &&
-          bluePos - prevBallPos[1] <= 12
+          isCollision(bluePos, prevBallPos[1])
+          // bluePos - prevBallPos[1] >= -5 &&
+          // bluePos - prevBallPos[1] <= 12
         )
           newState[2] = -Math.abs(prevBallPos[2]);
 

--- a/client/src/pages/Join.jsx
+++ b/client/src/pages/Join.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useState } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
+import { socket } from "../socket.js";
 
 function Join() {
   const [joinCode, setJoinCode] = useState("");
@@ -8,6 +9,7 @@ function Join() {
 
   const handleJoin = () => {
     if (joinCode.length === 4) {
+      socket.emit("joinRoom", joinCode);
       navigate(`/lobby/${joinCode.toUpperCase()}`);
     } else {
       alert("Please enter a valid 4-character join code.");

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -13,20 +13,31 @@ function Lobby() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const gameName = location.state?.gameName || "pong";
-  const gameConfig =
-    gameConfigs[String(gameName).toLowerCase()] || gameConfigs.pong;
+  // will need client logic to make this work
+  const gameName = location.state?.gameName || "Pong";
+  // const gameConfig =
+  //   gameConfigs[String(gameName).toLowerCase()] || gameConfigs.pong;
+  const gameConfig = gameConfigs.pong;
 
   const [players, setPlayers] = useState([1]);
-  const handleQuit = () => {};
+
+  const handleQuit = () => {
+    socket.emit("leaveRoom");
+    window.location.replace("/");
+  };
   const handleStart = () => {
-    socket.emit("startGame");
+    if (players < gameConfig.maxPlayers) {
+      //need to give error message to user
+    } else {
+      socket.emit("startGame");
+    }
   };
 
   useEffect(() => {
     socket.on("pongStart", () => {
       navigate(`/pong`);
     });
+
     socket.on("lobbyCount", (count) => setPlayers(count));
 
     return () => {

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useEffect, useState } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
+import { socket } from "../socket.js";
 
 const gameConfigs = {
   pong: { name: "Pong", maxPlayers: 2 },
@@ -16,26 +17,40 @@ function Lobby() {
   const gameConfig =
     gameConfigs[String(gameName).toLowerCase()] || gameConfigs.pong;
 
-  const [players, setPlayers] = useState(["Host"]);
+  const [players, setPlayers] = useState([1]);
   const handleQuit = () => {};
-  const handleStart = () => {};
+  const handleStart = () => {
+    socket.emit("startGame");
+  };
+
+  useEffect(() => {
+    socket.on("pongStart", () => {
+      navigate(`/pong`);
+    });
+    socket.on("lobbyCount", (count) => setPlayers(count));
+
+    return () => {
+      socket.removeAllListeners("pongStart");
+      socket.removeAllListeners("lobbyCount");
+      navigate(`/pong`);
+    };
+  }, []);
 
   return (
     <div className="lobby-container">
       <h1>{gameConfig.name} Lobby</h1>
       <p>Room Code: {roomID}</p>
       <p>
-        Players: {players.length} / {gameConfig.maxPlayers}
+        Players: {players} / {gameConfig.maxPlayers}
       </p>
-      <ul>
+      {/* <ul>
         {players.map((player, index) => (
           <li key={index}>{player}</li>
         ))}
-      </ul>
+      </ul> */}
       <button onClick={handleQuit}>Quit</button>
-      {players.length === gameConfig.maxPlayers && (
-        <button onClick={handleStart}>Start</button>
-      )}
+
+      <button onClick={handleStart}>Start</button>
     </div>
   );
 }

--- a/server/games/Pong.js
+++ b/server/games/Pong.js
@@ -1,0 +1,107 @@
+//game creation functions - might be moved to another file
+const createPongGame = function (roomName, io, activeRoomList) {
+  let firstRun = true;
+  let gameSentCount = 0;
+  const moveUp = (prevPos) => Math.max(prevPos - 5, 0);
+  const moveDown = (prevPos) => Math.min(prevPos + 5, 100);
+  const gameState = {
+    //starting gamestate
+    ballPos: [50, 50, 1, 1],
+    score: [0, 0],
+    redPos: 50,
+    bluePos: 50,
+  };
+  const isCollision = function (paddlePos, ballPos) {
+    const hitboxWidth = 19;
+    const fraction = paddlePos / 100;
+    const lowerBound = paddlePos - hitboxWidth * fraction;
+    const upperBound = lowerBound + hitboxWidth;
+
+    return ballPos >= lowerBound && ballPos <= upperBound;
+  };
+
+  const interval = setInterval(async () => {
+    const sockets = await io.to(roomName).fetchSockets();
+    if (sockets.length === 0) {
+      //activeRoomList.delete(roomName); TODO add a delete function
+      clearInterval(interval); //stop the game if all players have left
+    } else if (sockets.length === 1) {
+      return; //return if only one player
+    } else {
+      if (firstRun) {
+        //first loop logic setupt
+        firstRun = false;
+        sockets[0].emit("color", "red");
+        sockets[1].emit("color", "blue");
+
+        sockets[0].on("pongUp", () => {
+          sockets[1].emit("pongUp");
+          gameState.redPos = moveUp(gameState.redPos);
+        });
+        sockets[0].on("pongDown", () => {
+          sockets[1].emit("pongDown");
+          gameState.redPos = moveDown(gameState.redPos);
+        });
+
+        sockets[1].on("pongUp", () => {
+          sockets[0].emit("pongUp");
+          gameState.bluePos = moveUp(gameState.bluePos);
+        });
+        sockets[1].on("pongDown", () => {
+          sockets[0].emit("pongDown");
+          gameState.bluePos = moveDown(gameState.bluePos);
+        });
+
+        io.to(roomName).emit("pongGameState", gameState);
+      }
+
+      const prevGameState = structuredClone(gameState); //calculate one tick of game updates
+      if (gameState.ballPos[0] < 0) {
+        gameState.score[0] += 1;
+        gameState.ballPos = [25, 50, 1, prevGameState.ballPos[3]];
+        io.to(roomName).emit("pongGameState", gameState);
+      } else if (gameState.ballPos[0] > 100) {
+        gameState.score[1] += 1;
+        gameState.ballPos = [25, 50, 1, prevGameState.ballPos[3]];
+        io.to(roomName).emit("pongGameState", gameState);
+      } else {
+        if (
+          //check a player hit the ball (hitboxes can be looked at)
+          prevGameState.ballPos[0] + prevGameState.ballPos[2] <= 4 &&
+          isCollision(gameState.redPos, prevGameState.ballPos[1])
+          // prevGameState.redPos - prevGameState.ballPos[1] >= -5 &&
+          // prevGameState.redPos - prevGameState.ballPos[1] <= 12
+        )
+          gameState.ballPos[2] = Math.abs(prevGameState.ballPos[2]);
+        else if (
+          prevGameState.ballPos[0] + prevGameState.ballPos[2] >= 96 &&
+          isCollision(gameState.bluePos, prevGameState.ballPos[1])
+          // prevGameState.bluePos - prevGameState.ballPos[1] >= -5 &&
+          // prevGameState.bluePos - prevGameState.ballPos[1] <= 12
+        )
+          gameState.ballPos[2] = -Math.abs(prevGameState.ballPos[2]);
+
+        //check if player hit a wall
+        if (prevGameState.ballPos[1] + prevGameState.ballPos[3] <= 0)
+          gameState.ballPos[3] = Math.abs(prevGameState.ballPos[3]);
+        else if (prevGameState.ballPos[1] + prevGameState.ballPos[3] >= 100)
+          gameState.ballPos[3] = -Math.abs(prevGameState.ballPos[3]);
+
+        //update position based on velocity - old velocity used to match client
+        gameState.ballPos[0] =
+          prevGameState.ballPos[0] + prevGameState.ballPos[2];
+        gameState.ballPos[1] =
+          prevGameState.ballPos[1] + prevGameState.ballPos[3];
+      }
+
+      //currently just sync game on scores - let clients run smoothly
+      //Send the gamestate to avoid desyncs. Sending too often removes smoothness of client side running.
+      // if (gameSentCount > 60) {
+      //   io.to(roomName).emit("pongGameState", gameState);
+      //   gameSentCount = 0;
+      // } else gameSentCount += 1;
+    }
+  }, 30); //use 30ms for game logic updates when in code
+};
+
+module.exports = createPongGame;

--- a/server/games/Pong.js
+++ b/server/games/Pong.js
@@ -1,5 +1,5 @@
 //game creation functions - might be moved to another file
-const createPongGame = function (roomName, io, activeRoomList) {
+const createPongGame = function (roomName, io, activeRoomList, room) {
   let firstRun = true;
   let gameSentCount = 0;
   const moveUp = (prevPos) => Math.max(prevPos - 5, 0);
@@ -21,7 +21,7 @@ const createPongGame = function (roomName, io, activeRoomList) {
   };
 
   const interval = setInterval(async () => {
-    const sockets = await io.to(roomName).fetchSockets();
+    const sockets = room.sockets;
     if (sockets.length === 0) {
       //activeRoomList.delete(roomName); TODO add a delete function
       clearInterval(interval); //stop the game if all players have left

--- a/server/server.js
+++ b/server/server.js
@@ -3,11 +3,12 @@ const app = express();
 const path = require("path");
 const server = require("http").Server(app);
 const io = require("socket.io")(server);
+const createPongGame = require("./games/Pong");
 
 const port = process.env.PORT || 5001;
 
 const activeRoomList = [];
-const room = { game: "", numPlayers: 0, sockets: [] };
+const room = { numPlayers: 0, sockets: [] };
 
 app.use(express.static(path.join(__dirname, "../client/dist")));
 
@@ -16,8 +17,11 @@ app.use(express.static(path.join(__dirname, "../client/dist")));
 // }); //this works
 
 app.get("/", (req, res) => {
-  res.status(200);
-  res.sendFile(path.join(__dirname, "../client/dist", "index.html"));
+  console.log("redirect");
+  res.status(302);
+  res.redirect("./pong");
+
+  //res.sendFile(path.join(__dirname, "../client/dist", "index.html"));
 });
 
 app.get("/pong", (req, res) => {
@@ -34,7 +38,7 @@ io.on("connection", (socket) => {
   if (!activeRoomList.includes(roomName)) {
     //create game if not already created - will rework once flow is changed with create page
     activeRoomList.push(roomName);
-    createPongGame(roomName);
+    createPongGame(roomName, io, activeRoomList);
   }
 
   socket.on("disconnect", () => {
@@ -50,96 +54,4 @@ const joinRoom = function (roomName, socket) {
   socket.join(roomName);
 };
 
-//game creation functions - might be moved to another file
-const createPongGame = function (roomName) {
-  let firstRun = true;
-  let gameSentCount = 0;
-  const moveUp = (prevPos) => Math.max(prevPos - 5, 0);
-  const moveDown = (prevPos) => Math.min(prevPos + 5, 100);
-  const gameState = {
-    //starting gamestate
-    ballPos: [50, 50, 1, 1],
-    score: [0, 0],
-    redPos: 50,
-    bluePos: 50,
-  };
-
-  const interval = setInterval(async () => {
-    const sockets = await io.to(roomName).fetchSockets();
-    if (sockets.length === 0) {
-      //activeRoomList.delete(roomName); TODO add a delete function
-      clearInterval(interval); //stop the game if all players have left
-    } else if (sockets.length === 1) {
-      return; //return if only one player
-    } else {
-      if (firstRun) {
-        //first loop logic setupt
-        firstRun = false;
-        sockets[0].emit("color", "red");
-        sockets[1].emit("color", "blue");
-
-        sockets[0].on("pongUp", () => {
-          sockets[1].emit("pongUp");
-          gameState.redPos = moveUp(gameState.redPos);
-        });
-        sockets[0].on("pongDown", () => {
-          sockets[1].emit("pongDown");
-          gameState.redPos = moveDown(gameState.redPos);
-        });
-
-        sockets[1].on("pongUp", () => {
-          sockets[0].emit("pongUp");
-          gameState.bluePos = moveUp(gameState.bluePos);
-        });
-        sockets[1].on("pongDown", () => {
-          sockets[0].emit("pongDown");
-          gameState.bluePos = moveDown(gameState.bluePos);
-        });
-
-        io.to(roomName).emit("pongGameState", gameState);
-      }
-
-      const prevGameState = structuredClone(gameState); //calculate one tick of game updates
-      if (gameState.ballPos[0] < 0) {
-        gameState.score[0] += 1;
-        gameState.ballPos = [25, 50, 1, prevGameState.ballPos[3]];
-      } else if (gameState.ballPos[0] > 100) {
-        gameState.score[1] += 1;
-        gameState.ballPos = [25, 50, 1, prevGameState.ballPos[3]];
-      } else {
-        if (
-          //check a player hit the ball (hitboxes can be looked at)
-          prevGameState.ballPos[0] + prevGameState.ballPos[2] <= 4 &&
-          prevGameState.redPos - prevGameState.ballPos[1] >= -5 &&
-          prevGameState.redPos - prevGameState.ballPos[1] <= 12
-        )
-          gameState.ballPos[2] = Math.abs(prevGameState.ballPos[2]);
-        else if (
-          prevGameState.ballPos[0] + prevGameState.ballPos[2] >= 96 &&
-          prevGameState.bluePos - prevGameState.ballPos[1] >= -5 &&
-          prevGameState.bluePos - prevGameState.ballPos[1] <= 12
-        )
-          gameState.ballPos[2] = -Math.abs(prevGameState.ballPos[2]);
-
-        //check if player hit a wall
-        if (prevGameState.ballPos[1] + prevGameState.ballPos[3] <= 0)
-          gameState.ballPos[3] = Math.abs(prevGameState.ballPos[3]);
-        else if (prevGameState.ballPos[1] + prevGameState.ballPos[3] >= 100)
-          gameState.ballPos[3] = -Math.abs(prevGameState.ballPos[3]);
-
-        //update position based on velocity - old velocity used to match client
-        gameState.ballPos[0] =
-          prevGameState.ballPos[0] + prevGameState.ballPos[2];
-        gameState.ballPos[1] =
-          prevGameState.ballPos[1] + prevGameState.ballPos[3];
-      }
-
-      //Send the gamestate to avoid desyncs. Sending too often removes smoothness of client side running
-
-      if (gameSentCount > 60) {
-        io.to(roomName).emit("pongGameState", gameState);
-        gameSentCount = 0;
-      } else gameSentCount += 1;
-    }
-  }, 30); //use 30ms for game logic updates when in code
-};
+module.exports = { activeRoomList, io };

--- a/server/server.js
+++ b/server/server.js
@@ -37,9 +37,17 @@ io.on("connection", (socket) => {
     io.to(roomName).emit("lobbyCount", gameRoom.numPlayers);
   });
 
+  socket.on("leaveRoom", (roomCode) => {
+    if (roomName != "") {
+      leaveRoom(roomName, socket);
+    }
+
+    roomName = "";
+    gameRoom = undefined;
+  });
+
   socket.on("setGame", (game) => (gameType = game));
   socket.on("startGame", () => {
-    console.log("startgame", gameType);
     if (roomName != "") {
       //!activeRoomList.includes(roomName) &&
       //create game if not already created
@@ -88,6 +96,7 @@ const leaveRoom = function (roomName, socket) {
       //remove socket from list
       currentRoom.sockets.splice(socketIndex, 1);
     }
+    io.to(roomName).emit("lobbyCount", currentRoom.numPlayers);
 
     if ((currentRoom.numPlayers = 0)) {
       //remove room if empty

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,13 @@ const createPongGame = require("./games/Pong");
 const port = process.env.PORT || 5001;
 
 const activeRoomList = [];
-const room = { numPlayers: 0, sockets: [] };
+class room {
+  constructor(numPlayers = 0, sockets = [], name = "") {
+    this.numPlayers = numPlayers;
+    this.sockets = sockets;
+    this.name = name;
+  }
+}
 
 app.use(express.static(path.join(__dirname, "../client/dist")));
 
@@ -17,11 +23,8 @@ app.use(express.static(path.join(__dirname, "../client/dist")));
 // }); //this works
 
 app.get("/", (req, res) => {
-  console.log("redirect");
-  res.status(302);
-  res.redirect("./pong");
-
-  //res.sendFile(path.join(__dirname, "../client/dist", "index.html"));
+  res.status(200);
+  res.sendFile(path.join(__dirname, "../client/dist", "index.html"));
 });
 
 app.get("/pong", (req, res) => {
@@ -33,15 +36,16 @@ io.on("connection", (socket) => {
   console.log(`client with socket id ${socket.id} connected`);
 
   const roomName = "test_room"; // TODO change to room code sent by client once implemented
-  joinRoom(roomName, socket);
+  const gameRoom = joinRoom(roomName, socket);
 
   if (!activeRoomList.includes(roomName)) {
     //create game if not already created - will rework once flow is changed with create page
     activeRoomList.push(roomName);
-    createPongGame(roomName, io, activeRoomList);
+    createPongGame(roomName, io, activeRoomList, gameRoom);
   }
 
   socket.on("disconnect", () => {
+    leaveRoom(roomName, socket);
     console.log(`client with socket id ${socket.id} disconnected`);
   });
 });
@@ -51,7 +55,37 @@ server.listen(port, () => {
 });
 
 const joinRoom = function (roomName, socket) {
+  const roomIndex = activeRoomList.findIndex((room) => room.name === roomName);
   socket.join(roomName);
+  if (roomIndex === -1) {
+    const newGame = new room();
+    newGame.numPlayers += 1;
+    newGame.sockets.push(socket);
+    newGame.name = roomName;
+    activeRoomList.push(newGame);
+    return newGame;
+  } else {
+    const currentGame = activeRoomList[roomIndex];
+    currentGame.numPlayers += 1;
+    currentGame.sockets.push(socket);
+    return currentGame;
+  }
 };
 
-module.exports = { activeRoomList, io };
+const leaveRoom = function (roomName, socket) {
+  const roomIndex = activeRoomList.findIndex((room) => room.name === roomName);
+  if (roomIndex >= 0) {
+    const currentRoom = activeRoomList[roomIndex];
+    room.numPlayers -= 1;
+    const socketIndex = array.indexOf(socket);
+    if (socketIndex !== -1) {
+      //remove socket from list
+      room.sockets.splice(socketIndex, 1);
+    }
+
+    if ((room.numPlayers = 0)) {
+      //remove room if empty
+      activeRoomList.splice(roomIndex, 1);
+    }
+  }
+};


### PR DESCRIPTION
I have successfully implemented game lobbies to have multiple separate games at once. The entire ui flow from hosting and joining a game to starting should be working when you start from the home page (/). This involved creating a room class on the backend to track this and communication between the client and the server through socket.io. One thing you might want to look at are changes to the frontend I made while implementing this such as removing the dedicated host button on the game selection page. 

My approach has two known deficiencies. It relies on the onclick functions so navigating directly via urls breaks this approach. On the server, it relies on keeping state per socket so games can break if the client disconnects and then reconnects with a new socket id in the middle of the flow.